### PR TITLE
Fixes incorrect search paths for pyrefly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
 
 [tool.pyrefly]
 search-path = [
-    "Freed/src/",
-    "Freed/Tests/"
+    "src/",
+    "Tests/"
 ]
 project-includes = ["src", "Tests"]


### PR DESCRIPTION
The search paths in the pyproject.toml config for Pyrefly Duplicated the project's name, and with a typo too! This caused a warning on running Pyrefly checks that I had not caught before. Now the warnings are gone.